### PR TITLE
Fix StopIteration error in random_index_generator

### DIFF
--- a/watermark_regularizers.py
+++ b/watermark_regularizers.py
@@ -2,9 +2,8 @@ from keras import backend as K
 from keras.regularizers import Regularizer
 import numpy as np
 
-def random_index_generator(count):
-    indices = np.arange(0, count)
-    np.random.shuffle(indices)
+def random_index_generator(count, size):
+    indices = np.random.randint(0, count, size)
 
     for idx in indices:
         yield idx
@@ -37,13 +36,13 @@ class WatermarkRegularizer(Regularizer):
             self.w = np.random.randn(w_rows, w_cols)
         elif self.wtype == 'direct':
             self.w = np.zeros((w_rows, w_cols), dtype=None)
-            rand_idx_gen = random_index_generator(w_rows)
+            rand_idx_gen = random_index_generator(w_rows, w_cols)
 
             for col in range(w_cols):
                 self.w[next(rand_idx_gen)][col] = 1.
         elif self.wtype == 'diff':
             self.w = np.zeros((w_rows, w_cols), dtype=None)
-            rand_idx_gen = random_index_generator(w_rows)
+            rand_idx_gen = random_index_generator(w_rows, w_cols * 2)
 
             for col in range(w_cols):
                 self.w[next(rand_idx_gen)][col] = 1.


### PR DESCRIPTION
The `random_index_generator()` generates a numpy array of size `w_rows`, so if `w_rows < w_cols`, a StopIteration error will occur.
https://github.com/yu4u/dnn-watermark/blob/00e89e45ac272e44210805a14008ed70409f310e/watermark_regularizers.py#L6
I fixed it to use `numpy.random.randint()` to generate a numpy array of the required size (w_cols for *direct*, w_cols * 2 for *diff*).
https://github.com/FunabikiKeisuke/dnn-watermark/blob/fix-generator/watermark_regularizers.py#L6